### PR TITLE
SOへのマッピングの追加・修正、ラベルやdescriptionの追加など

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 First argument is a tab-delimited file exported from Ensembl Mart service, whose header line is blow.
 
-    Gene stable ID  Transcript stable ID    Protein stable ID       Exon stable ID  Gene name       Gene description        Transcript name Chromosome/scaffold name        Gene start (bp) Gene end (bp)   Strand  Transcript start (bp)   Transcript end (bp)     Gene type
+    Gene stable ID  Transcript stable ID    Protein stable ID       Exon stable ID  Gene name       Gene description        Transcript name Chromosome/scaffold name        Gene start (bp) Gene end (bp)   Strand  Transcript start (bp)   Transcript end (bp)     Gene type   Transcript type
 
 
 Second argument is a tab-delimited file exported from Ensembl Mart service, whose header line is blow.

--- a/README.md
+++ b/README.md
@@ -8,17 +8,17 @@
 
 ### Input files
 
-First argument is a tab-delimited file exported from Ensembl Mart service, whose header line is blow.
+First argument is a tab-delimited file exported from Ensembl Mart service, whose header line is below.
 
     Gene stable ID  Transcript stable ID    Protein stable ID       Exon stable ID  Gene name       Gene description        Transcript name Chromosome/scaffold name        Gene start (bp) Gene end (bp)   Strand  Transcript start (bp)   Transcript end (bp)     Gene type   Transcript type
 
 
-Second argument is a tab-delimited file exported from Ensembl Mart service, whose header line is blow.
+Second argument is a tab-delimited file exported from Ensembl Mart service, whose header line is below.
 
     Gene stable ID  Transcript stable ID    Exon stable ID  Exon region start (bp)  Exon region end (bp)    Exon rank in transcript
 
-Third argument is a tab-delimited file exported from Ensembl Mart service, whose header line is blow.
+Third argument is a tab-delimited file exported from Ensembl Mart service, whose header line is below.
 
     Gene stable ID  Transcript stable ID    HGNC ID UniProtKB/Swiss-Prot ID UniProtKB/TrEMBL ID
 
-Ensembl BioMart service for GRCh37 is availele at [here](https://grch37.ensembl.org/biomart/martview).
+Ensembl BioMart service for GRCh37 is available at [here](https://grch37.ensembl.org/biomart/martview).

--- a/rdf_converter_ensembl_grch37.rb
+++ b/rdf_converter_ensembl_grch37.rb
@@ -203,11 +203,7 @@ module Ensembl
       @gene_hash.keys.each do |gene_id|
         print "ens:#{gene_id} a term:#{@gene_hash[gene_id][1]} ;\n"
         print "    a obo:#{Term2SO_gene[@gene_hash[gene_id][1]]} ;\n" if Term2SO_gene.key?(@gene_hash[gene_id][1])
-        if @gene_hash[gene_id][0] == ""
-          print "    rdfs:label \"#{gene_id}\" ;\n"
-        else
-          print "    rdfs:label \"#{@gene_hash[gene_id][0]}\" ;\n"
-        end
+        print "    rdfs:label \"#{@gene_hash[gene_id][0]}\" ;\n"
         print "    dcterms:identifier \"#{gene_id}\" ;\n"
         print "    dcterms:description \"#{@gene_hash[gene_id][2]}\" ;\n"
         print "    obo:RO_0002162 taxon:9606 ;\n"
@@ -249,11 +245,7 @@ module Ensembl
           print "enst:#{transcript_id} a term:#{@transcript_hash[transcript_id][6]} ;\n"
           print "    a ens:#{Term2SO_transcript[@transcript_hash[transcript_id][6]]} ;\n" if Term2SO_transcript.key?(@transcript_hash[transcript_id][6])
           print "    dcterms:identifier \"#{transcript_id}\" ;\n"
-          if @transcript_hash[transcript_id][5] == ""
-            print "    rdfs:label \"#{transcript_id}\" ;\n"
-          else
-            print "    rdfs:label \"#{@transcript_hash[transcript_id][5]}\" ;\n"
-          end
+          print "    rdfs:label \"#{@transcript_hash[transcript_id][5]}\" ;\n"
           print "    obo:BFO_0000050 ens:#{gene_id} ;\n"
           print "    so:part_of ens:#{gene_id} ;\n"
           print "    so:transcribed_from ens:#{gene_id} ;\n"

--- a/rdf_converter_ensembl_grch37.rb
+++ b/rdf_converter_ensembl_grch37.rb
@@ -336,7 +336,7 @@ module Ensembl
 end # end of Module
 
 def help
-  print "Usage: ruby rdf_converter_ensembl_rgch37.rb [options]\n"
+  print "Usage: ruby rdf_converter_ensembl_grch37.rb [options]\n"
   print "  -g, --gene path to the file for gene structures\n"
   print "  -e, --exon path to the file for exon structures\n"
   print "  -x, --xlink path to the file for cross links\n"

--- a/rdf_converter_ensembl_grch37.rb
+++ b/rdf_converter_ensembl_grch37.rb
@@ -12,7 +12,6 @@ module Ensembl
      "enst: <http://rdf.ebi.ac.uk/resource/ensembl.transcript/>",
      "ense: <http://rdf.ebi.ac.uk/resource/ensembl.exon/>",
      "rdfs: <http://www.w3.org/2000/01/rdf-schema#>",
-     "dc: <http://purl.org/dc/elements/1.1/>",
      "dcterms: <http://purl.org/dc/terms/>",
      "ensgido: <http://identifiers.org/ensembl/>",
      "term: <http://rdf.ebi.ac.uk/terms/ensembl/>",
@@ -210,7 +209,7 @@ module Ensembl
           print "    rdfs:label \"#{@gene_hash[gene_id][0]}\" ;\n"
         end
         print "    dcterms:identifier \"#{gene_id}\" ;\n"
-        print "    dc:description \"#{@gene_hash[gene_id][2]}\" ;\n"
+        print "    dcterms:description \"#{@gene_hash[gene_id][2]}\" ;\n"
         print "    obo:RO_0002162 taxon:9606 ;\n"
         if @gene2extls.key?(gene_id)
           print "    rdfs:seeAlso <http://identifiers.org/ensembl/#{gene_id}> ,\n"

--- a/rdf_converter_ensembl_rgch37.rb
+++ b/rdf_converter_ensembl_rgch37.rb
@@ -28,57 +28,67 @@ module Ensembl
   end
   module_function :prefixes
 
-  Term2SO = Hash[*[
-  "3prime_overlapping_ncrna", "",
-  "antisense", "",
-  "bidirectional_promoter_lncrna", "",
-  "IG_C_gene", "",
-  "IG_C_pseudogene", "",
-  "IG_D_gene", "SO_0000510",
-  "IG_J_gene", "",
-  "IG_J_pseudogene", "",
-  "IG_V_gene", "",
-  "IG_V_pseudogene", "",
-  "lncRNA", "SO_0001463",
-  "lincRNA", "SO_0001641",
-  "LRG_gene", "",
-  "macro_lncRNA", "",
+  Term2SO_gene = Hash[*[
+  "IG_C_gene", "SO_0002123",
+  "IG_C_pseudogene", "SO_0002100",
+  "IG_D_gene", "SO_0002124",
+  "IG_J_gene", "SO_0002125",
+  "IG_J_pseudogene", "SO_0002101",
+  "IG_pseudogene", "SO_0002098",
+  "IG_V_gene", "SO_0002126",
+  "IG_V_pseudogene", "SO_0002102",
+  "lncRNA", "SO_0002127",
   "miRNA", "SO_0001265",
-  "misc_RNA", "SO_0000356",
-  "Mt_rRNA", "",
+  "misc_RNA", "SO_0001263",
+  "Mt_rRNA", "SO_0002363",
   "Mt_tRNA", "SO_0000088",
-  "non_coding", "",
-  "nonsense_mediated_decay", "SO_0001621",
-  "non_stop_decay", "",
-  "polymorphic_pseudogene", "SO_0000336",
-  "processed_pseudogene", "",
-  "processed_transcript", "SO_0001503",
-  "protein", "",
+  "polymorphic_pseudogene", "SO_0001841",
+  "processed_pseudogene", "SO_0000043",
   "protein_coding", "SO_0001217",
   "pseudogene", "SO_0000336",
-  "retained_intron", "SO_0000681",
-  "ribozyme", "",
+  "ribozyme", "SO_0002181",
   "rRNA", "SO_0001637",
-  "scaRNA", "",
-  "sense_intronic", "",
-  "sense_overlapping", "",
+  "rRNA_pseudogene", "SO_0000777",
+  "scaRNA", "SO_0002339",
+  "scRNA", "SO_0001266",
   "snoRNA", "SO_0001267",
   "snRNA", "SO_0001268",
-  "sRNA", "",
-  "TEC", "",
-  "transcribed_processed_pseudogene", "",
-  "transcribed_unitary_pseudogene", "",
-  "transcribed_unprocessed_pseudogene", "",
-  "translated_unprocessed_pseudogene", "",
-  "TR_C_gene", "SO_0000478",
-  "TR_D_gene", "",
-  "TR_J_gene", "SO_0000470",
-  "TR_J_pseudogene", "",
-  "TR_V_gene", "SO_0000466",
-  "TR_V_pseudogene", "",
-  "unitary_pseudogene", "",
-  "unprocessed_pseudogene", "",
-  "vaultRNA", "" ]]
+  "sRNA", "SO_0002342",
+  "transcribed_processed_pseudogene", "SO_0002109",
+  "transcribed_unitary_pseudogene", "SO_0002108",
+  "transcribed_unprocessed_pseudogene", "SO_0002107",
+  "translated_processed_pseudogene", "SO_0002105",
+  "translated_unprocessed_pseudogene", "SO_0002106",
+  "TR_C_gene", "SO_0002134",
+  "TR_D_gene", "SO_0002135",
+  "TR_J_gene", "SO_0002136",
+  "TR_J_pseudogene", "SO_0002104",
+  "TR_V_gene", "SO_0002137",
+  "TR_V_pseudogene", "SO_0002103",
+  "unitary_pseudogene", "SO_0001759",
+  "unprocessed_pseudogene", "SO_0001760",
+  "vault_RNA", "SO_0002358"]]
+
+  Term2SO_transcript = Hash[*[
+  "lncRNA", "SO_0001877",
+  "miRNA", "SO_0000276",
+  "misc_RNA", "SO_0000655",
+  "Mt_rRNA", "SO_0002128",
+  "Mt_tRNA", "SO_0002129",
+  "nonsense_mediated_decay", "SO_0002114",
+  "non_stop_decay", "SO_0002130",
+  "processed_transcript", "SO_0001503",
+  "protein_coding", "SO_0000234",
+  "retained_intron", "SO_0000681",
+  "ribozyme", "SO_0000374",
+  "rRNA", "SO_0000252",
+  "scaRNA", "SO_0002095",
+  "scRNA", "SO_0000013",
+  "snoRNA", "SO_0000275",
+  "snRNA", "SO_0000274",
+  "sRNA", "SO_0002247",
+  "TEC", "SO_0002139",
+  "vault_RNA", "SO_0000404"]]
 
   ENST = "http://rdf.ebi.ac.uk/resource/ensembl.transcript/"
 
@@ -163,7 +173,10 @@ module Ensembl
                                                          h[:chromosome_scaffold_name],
                                                          h[:transcript_start_bp].to_i,
                                                          h[:transcript_end_bp].to_i,
-                                                         h[:strand].to_i]
+                                                         h[:strand].to_i,
+                                                         h[:transcript_name],
+                                                         h[:transcript_type]
+                                                       ]
         else
           @transcript_hash[h[:transcript_stable_id]][0] << h[:exon_stable_id]
         end
@@ -190,7 +203,7 @@ module Ensembl
       exon_used = []
       @gene_hash.keys.each do |gene_id|
         print "ens:#{gene_id} a term:#{@gene_hash[gene_id][1]} ;\n"
-        print "    a obo:#{Term2SO[@gene_hash[gene_id][1]]} ;\n" unless Term2SO[@gene_hash[gene_id][1]] == ""
+        print "    a obo:#{Term2SO_gene[@gene_hash[gene_id][1]]} ;\n" if Term2SO_gene.key?(@gene_hash[gene_id][1])
         print "    rdfs:label \"#{@gene_hash[gene_id][0]}\" ;\n"
         print "    dcterms:identifier \"#{gene_id}\" ;\n"
         print "    dc:description \"#{@gene_hash[gene_id][2]}\" ;\n"
@@ -230,8 +243,8 @@ module Ensembl
         print "    ] .\n"
         print "\n"
         @gene2transcripts[gene_id].each do |transcript_id|
-          print "enst:#{transcript_id} a term:#{@gene_hash[gene_id][1]} ;\n"
-          print "    a ens:#{Term2SO[@gene_hash[gene_id][1]]} ;\n" unless Term2SO[@gene_hash[gene_id][1]] == ""
+          print "enst:#{transcript_id} a term:#{@transcript_hash[transcript_id][6]} ;\n"
+          print "    a ens:#{Term2SO_transcript[@transcript_hash[transcript_id][6]]} ;\n" if Term2SO_transcript.key?(@transcript_hash[transcript_id][6])
           print "    dcterms:identifier \"#{transcript_id}\" ;\n"
           print "    obo:BFO_0000050 ens:#{gene_id} ;\n"
           print "    so:part_of ens:#{gene_id} ;\n"

--- a/rdf_converter_ensembl_rgch37.rb
+++ b/rdf_converter_ensembl_rgch37.rb
@@ -246,6 +246,7 @@ module Ensembl
           print "enst:#{transcript_id} a term:#{@transcript_hash[transcript_id][6]} ;\n"
           print "    a ens:#{Term2SO_transcript[@transcript_hash[transcript_id][6]]} ;\n" if Term2SO_transcript.key?(@transcript_hash[transcript_id][6])
           print "    dcterms:identifier \"#{transcript_id}\" ;\n"
+          print "    rdfs:label \"#{@transcript_hash[transcript_id][5]}\" ;\n"
           print "    obo:BFO_0000050 ens:#{gene_id} ;\n"
           print "    so:part_of ens:#{gene_id} ;\n"
           print "    so:transcribed_from ens:#{gene_id} ;\n"

--- a/rdf_converter_ensembl_rgch37.rb
+++ b/rdf_converter_ensembl_rgch37.rb
@@ -204,7 +204,11 @@ module Ensembl
       @gene_hash.keys.each do |gene_id|
         print "ens:#{gene_id} a term:#{@gene_hash[gene_id][1]} ;\n"
         print "    a obo:#{Term2SO_gene[@gene_hash[gene_id][1]]} ;\n" if Term2SO_gene.key?(@gene_hash[gene_id][1])
-        print "    rdfs:label \"#{@gene_hash[gene_id][0]}\" ;\n"
+        if @gene_hash[gene_id][0] == ""
+          print "    rdfs:label \"#{gene_id}\" ;\n"
+        else
+          print "    rdfs:label \"#{@gene_hash[gene_id][0]}\" ;\n"
+        end
         print "    dcterms:identifier \"#{gene_id}\" ;\n"
         print "    dc:description \"#{@gene_hash[gene_id][2]}\" ;\n"
         print "    obo:RO_0002162 taxon:9606 ;\n"
@@ -246,7 +250,11 @@ module Ensembl
           print "enst:#{transcript_id} a term:#{@transcript_hash[transcript_id][6]} ;\n"
           print "    a ens:#{Term2SO_transcript[@transcript_hash[transcript_id][6]]} ;\n" if Term2SO_transcript.key?(@transcript_hash[transcript_id][6])
           print "    dcterms:identifier \"#{transcript_id}\" ;\n"
-          print "    rdfs:label \"#{@transcript_hash[transcript_id][5]}\" ;\n"
+          if @transcript_hash[transcript_id][5] == ""
+            print "    rdfs:label \"#{transcript_id}\" ;\n"
+          else
+            print "    rdfs:label \"#{@transcript_hash[transcript_id][5]}\" ;\n"
+          end
           print "    obo:BFO_0000050 ens:#{gene_id} ;\n"
           print "    so:part_of ens:#{gene_id} ;\n"
           print "    so:transcribed_from ens:#{gene_id} ;\n"

--- a/rdf_converter_ensembl_rgch37.rb
+++ b/rdf_converter_ensembl_rgch37.rb
@@ -290,7 +290,7 @@ module Ensembl
             exon_used << exon[0]
             print "ense:#{exon[0]} a obo:SO_0000147 ;\n" # so:exon
             print "    rdfs:label \"#{exon[0]}\" ;\n"
-            print "    dcterms:identifiers \"#{exon[0]}\" ;\n"
+            print "    dcterms:identifier \"#{exon[0]}\" ;\n"
             print "    so:part_of enst:#{transcript_id} ;\n"
             print "    obo:BFO_0000050 enst:#{transcript_id} ;\n"
             print "    faldo:location [\n"

--- a/rdf_converter_ensembl_rgch37.rb
+++ b/rdf_converter_ensembl_rgch37.rb
@@ -12,6 +12,7 @@ module Ensembl
      "enst: <http://rdf.ebi.ac.uk/resource/ensembl.transcript/>",
      "ense: <http://rdf.ebi.ac.uk/resource/ensembl.exon/>",
      "rdfs: <http://www.w3.org/2000/01/rdf-schema#>",
+     "dc: <http://purl.org/dc/elements/1.1/>",
      "dcterms: <http://purl.org/dc/terms/>",
      "ensgido: <http://identifiers.org/ensembl/>",
      "term: <http://rdf.ebi.ac.uk/terms/ensembl/>",
@@ -192,6 +193,7 @@ module Ensembl
         print "    a obo:#{Term2SO[@gene_hash[gene_id][1]]} ;\n" unless Term2SO[@gene_hash[gene_id][1]] == ""
         print "    rdfs:label \"#{@gene_hash[gene_id][0]}\" ;\n"
         print "    dcterms:identifier \"#{gene_id}\" ;\n"
+        print "    dc:description \"#{@gene_hash[gene_id][2]}\" ;\n"
         print "    obo:RO_0002162 taxon:9606 ;\n"
         if @gene2extls.key?(gene_id)
           print "    rdfs:seeAlso <http://identifiers.org/ensembl/#{gene_id}> ,\n"


### PR DESCRIPTION
ほとんどは細かい修正ですが、SO について補足します(https://github.com/skwsm/rdf_converter_ensembl_human_grch37/commit/02b9ce98b7dae6f6ff2aca551e2ce55407300728 このコミット) 。
従来はこのページ https://useast.ensembl.org/info/genome/genebuild/biotypes.html にあるものに対して SO へのマッピングが定義されていたようですが、
少なくとも現在 BioMart の Gene type の出力として得られるものはこのページにあるものとは少し異なります。
今回は実際に type として得られる文字列に対して SO への割り当てを行いました。
従来は SO のタームが割り当てられていないものも多かったですが、今回調べ直したところ大半のものには対応する SO のタームが見つかりました。
また、もともと transcript の class には gene と同じものが使われていましたが、Ensembl の biotype は transcript 単位に対しても定義されています。
そこで `Term2SO` のハッシュテーブルを transcript 用と gene 用とに分割し、transcript には transcript の biotype を使うように修正しました。
